### PR TITLE
adding references to other libraries for grids

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -22,3 +22,63 @@
   booktitle={SQAMIA},
   year={2015}
 }
+
+@MISC{sklearn,
+  title        = "{sklearn.model\_selection.ParameterGrid} --- scikit-learn
+                  0.23.1 documentation",
+  abstract     = "scikit-learn: machine learning in Python",
+  howpublished = "\url{https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.ParameterGrid.html}",
+  note         = "Accessed: 2020-6-20"
+}
+
+@MISC{grid_regular,
+  title        = "grid\_regular: Create grids of tuning parameters in dials:
+                  Tools for Creating Tuning Parameter Values",
+  author       = "[aut, Max Kuhn and {cre]} and [cph], Rstudio",
+  abstract     = "Random and regular grids can be created for any number of
+                  parameter objects.",
+  month        =  apr,
+  year         =  2020,
+  howpublished = "\url{https://rdrr.io/cran/dials/man/grid_regular.html}",
+  note         = "Accessed: 2020-6-20"
+}
+
+
+@MISC{keras,
+  title        = "How to Grid Search Hyperparameters for Deep Learning Models
+                  in Python With Keras - Machine Learning Mastery",
+  booktitle    = "Machine Learning Mastery",
+  author       = "Brownlee, Jason",
+  abstract     = "Hyperparameter optimization is a big part of deep learning.
+                  The reason is that neural networks are notoriously difficult
+                  to configure and there are a lot of parameters that need to
+                  be set. On top of that, individual models can be very slow to
+                  train. In this post you will discover how you can use the
+                  grid",
+  month        =  aug,
+  year         =  2016,
+  howpublished = "\url{https://machinelearningmastery.com/grid-search-hyperparameters-deep-learning-models-python-keras/}",
+  note         = "Accessed: 2020-6-20"
+}
+
+
+@MISC{h2o,
+  title        = "Grid (Hyperparameter) Search --- {H2O} 3.30.0.5 documentation",
+  howpublished = "\url{https://docs.h2o.ai/h2o/latest-stable/h2o-docs/grid-search.html}",
+  note         = "Accessed: 2020-6-20",
+  year         = 2020
+}
+
+
+@MISC{Willkoehrsen2018-hm,
+  title        = "Intro to Model Tuning: Grid and Random Search",
+  booktitle    = "Kaggle",
+  author       = "{willkoehrsen}",
+  abstract     = "Explore and run machine learning code with Kaggle Notebooks |
+                  Using data from multiple data sources",
+  month        =  jul,
+  year         =  2018,
+  howpublished = "\url{https://kaggle.com/willkoehrsen/intro-to-model-tuning-grid-and-random-search}",
+  note         = "Accessed: 2020-6-20"
+}
+

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -23,43 +23,40 @@
   year={2015}
 }
 
-@MISC{sklearn,
-  title        = "{sklearn.model\_selection.ParameterGrid} --- scikit-learn
-                  0.23.1 documentation",
-  abstract     = "scikit-learn: machine learning in Python",
-  howpublished = "\url{https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.ParameterGrid.html}",
-  note         = "Accessed: 2020-6-20"
+@article{sklearn,
+ title={Scikit-learn: Machine Learning in {P}ython},
+ author={Pedregosa, F. and Varoquaux, G. and Gramfort, A. and Michel, V.
+         and Thirion, B. and Grisel, O. and Blondel, M. and Prettenhofer, P.
+         and Weiss, R. and Dubourg, V. and Vanderplas, J. and Passos, A. and
+         Cournapeau, D. and Brucher, M. and Perrot, M. and Duchesnay, E.},
+ journal={Journal of Machine Learning Research},
+ volume={12},
+ pages={2825--2830},
+ year={2011}
 }
 
-@MISC{grid_regular,
-  title        = "grid\_regular: Create grids of tuning parameters in dials:
-                  Tools for Creating Tuning Parameter Values",
-  author       = "[aut, Max Kuhn and {cre]} and [cph], Rstudio",
-  abstract     = "Random and regular grids can be created for any number of
-                  parameter objects.",
-  month        =  apr,
-  year         =  2020,
-  howpublished = "\url{https://rdrr.io/cran/dials/man/grid_regular.html}",
-  note         = "Accessed: 2020-6-20"
+@article{grid_regular,
+author = "Beilsten-Edmands, James and Winter, Graeme and Gildea, Richard and Parkhurst, James and Waterman, David and Evans, Gwyndaf",
+title = "{Scaling diffraction data in the {\it DIALS} software package: algorithms and new approaches for multi-crystal scaling}",
+journal = "Acta Crystallographica Section D",
+year = "2020",
+volume = "76",
+number = "4",
+pages = "385--399",
+month = "Apr",
+doi = {10.1107/S2059798320003198},
+url = {https://doi.org/10.1107/S2059798320003198},
+abstract = {In processing X-ray diffraction data, the intensities obtained from integration of the diffraction images must be corrected for experimental effects in order to place all intensities on a common scale both within and between data collections. Scaling corrects for effects such as changes in sample illumination, absorption and, to some extent, global radiation damage that cause the measured intensities of symmetry-equivalent observations to differ throughout a data set. This necessarily requires a prior evaluation of the point-group symmetry of the crystal. This paper describes and evaluates the scaling algorithms implemented within the {\it DIALS} data-processing package and demonstrates the effectiveness and key features of the implementation on example macromolecular crystallographic rotation data. In particular, the scaling algorithms enable new workflows for the scaling of multi-crystal or multi-sweep data sets, providing the analysis required to support current trends towards collecting data from ever-smaller samples. In addition, the implementation of a free-set validation method is discussed, which allows the quantification of the suitability of scaling-model and algorithm choices.},
+keywords = {diffraction, crystallography, multi-crystal, data analysis, scaling},
 }
 
-
-@MISC{keras,
-  title        = "How to Grid Search Hyperparameters for Deep Learning Models
-                  in Python With Keras - Machine Learning Mastery",
-  booktitle    = "Machine Learning Mastery",
-  author       = "Brownlee, Jason",
-  abstract     = "Hyperparameter optimization is a big part of deep learning.
-                  The reason is that neural networks are notoriously difficult
-                  to configure and there are a lot of parameters that need to
-                  be set. On top of that, individual models can be very slow to
-                  train. In this post you will discover how you can use the
-                  grid",
-  month        =  aug,
-  year         =  2016,
-  howpublished = "\url{https://machinelearningmastery.com/grid-search-hyperparameters-deep-learning-models-python-keras/}",
-  note         = "Accessed: 2020-6-20"
-}
+@online{keras,
+  title={Keras},
+  author={Chollet, Francois and others},
+  year={2015},
+  publisher={GitHub},
+  url={https://github.com/fchollet/keras},
+} 
 
 
 @MISC{h2o,

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -34,6 +34,24 @@ specifications are stored in a simple yaml configuration that the library helps 
 and features include interactive debugging, interactive report generation,
 and provided metrics (Python decorators) that can assist with research.
 
+## Background
+
+While several scientific libraries [@sklearn, @grid_regular] make it possible to
+generate parameter grids within code, they require a substantial list of
+numerical library dependencies that might be overkill for the user's needs,
+and further, they don't allow for representation of grids outside of the code.
+Additionally, these libraries do not natively allow for interactive debugging,
+collection of metrics around grids, or report generation. Another subset
+of grid generation libraries are specifically intended for hyperparameter tuning
+[@keras, @h2o, @Willkoehrsen2018-hm], and are thus packaged
+alongside machine learning libraries. While these libraries are rich and hugely
+useful for their intended purposes, none of them present a domain-agnostic,
+simple grid definition that can be defined outside of the programming language (e.g., R, Python)
+code that uses it. The landscape is missing a library that places grids alongside
+code, and can define them without needing it. GridTest offers this ability,
+and further, introduces a new paradigm that grids might be shared between
+code bases as their own entity, and are not required to be embedded within it.
+
 ## Use Cases
 
 GridTest has use cases well beyond testing, because parameterization is used


### PR DESCRIPTION
This will add references to several libraries that are intended for grid generation (usually for machine learning) and some description of how they differ from GridTest. This will close #34.

Signed-off-by: vsoch <vsochat@stanford.edu>